### PR TITLE
`repack.py` fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Python script(s) that can unpack \.pak\\\.pab\\.img.xen file formats and repack 
 - Added re-mipmapping to textures when repacking
 ### 11/09/2025
 - Linux support
+- Added automatic downloading of texconv
 --------------------
 
 Video showcase on how the python scripts work <br />

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Python script(s) that can unpack \.pak\\\.pab\\.img.xen file formats and repack them accordingly.
 
 ## Make sure you have these dependencies installed
-https://www.python.org/downloads/ __(REQUIRED)__ <br /> <br />
+[Python 3.7+](https://www.python.org/downloads/) __(REQUIRED)__ <br />
 
 --------------------
 
@@ -12,7 +12,8 @@ https://www.python.org/downloads/ __(REQUIRED)__ <br /> <br />
 ### 11/08/2025
 - Added batch extraction/repacking
 - Added re-mipmapping to textures when repacking
-
+### 11/09/2025
+- Linux support
 --------------------
 
 Video showcase on how the python scripts work <br />

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ Python script(s) that can unpack \.pak\\\.pab\\.img.xen file formats and repack 
 
 ## Make sure you have these dependencies installed
 https://www.python.org/downloads/ __(REQUIRED)__ <br /> <br />
-https://github.com/microsoft/DirectXTex/releases/download/oct2025/texconv.exe __(REQUIRED)__
-- place this in the root folder of where you're running the scripts for repack.py
 
 --------------------
 

--- a/repack.py
+++ b/repack.py
@@ -25,25 +25,23 @@ def regenerate_mipmaps(dds_path, mip_count):
     temp_dir = os.path.join(os.path.dirname(dds_path), "_temp_mipmaps")
     os.makedirs(temp_dir, exist_ok=True)
 
-    if os.name == "nt":
-        cmd = [
-            "texconv",
-            "-m", str(mip_count),
-            "-nologo",
-            "-y",
-            "-o", temp_dir,
-            dds_path
-        ]
-    elif os.name == "posix":
-        cmd = [
-            "wine",
-            "texconv.exe",
-            "-m", str(mip_count),
-            "-nologo",
-            "-y",
-            "-o", temp_dir,
-            dds_path
-        ]
+    if os.name == "posix":
+        dds_path_win = f"Z:{dds_path.replace('/', '\\')}"
+        temp_dir_win = f"Z:{temp_dir.replace('/', '\\')}"
+    else:
+        dds_path_win = dds_path
+        temp_dir_win = temp_dir
+
+    cmd = [
+        "texconv" if os.name == "nt" else "wine",
+        "texconv.exe",
+        "-m", str(mip_count),
+        "-nologo",
+        "-y",
+        "-o", temp_dir_win,
+        dds_path_win
+    ]
+    print(f"{cmd}")
 
     if not os.path.exists("./texconv.exe"):
         url = "https://github.com/microsoft/DirectXTex/releases/download/oct2025/texconv.exe"
@@ -59,12 +57,12 @@ def regenerate_mipmaps(dds_path, mip_count):
 
     print(f"    Regenerating {mip_count} mipmaps for {os.path.basename(dds_path)}...")
     try:
-        subprocess.run(cmd, check=True, capture_output=True)
+        subprocess.run(cmd, check=True)
     except subprocess.CalledProcessError as e:
         print(f"    texconv failed: {e}")
         return dds_path
 
-    regenerated_name = os.path.splitext(os.path.basename(dds_path))[0] + ".DDS"
+    regenerated_name = os.path.splitext(os.path.basename(dds_path))[0] + ".dds"
     regenerated_path = os.path.join(temp_dir, regenerated_name)
     if os.path.exists(regenerated_path):
         os.replace(regenerated_path, dds_path)

--- a/repack.py
+++ b/repack.py
@@ -44,6 +44,8 @@ def regenerate_mipmaps(dds_path, mip_count):
             "-o", temp_dir,
             dds_path
         ]
+
+    if not os.path.exists("./texconv.exe"):
         url = "https://github.com/microsoft/DirectXTex/releases/download/oct2025/texconv.exe"
         dest = "./texconv.exe"
         print(f"Downloading {url}...")
@@ -53,8 +55,7 @@ def regenerate_mipmaps(dds_path, mip_count):
         with open(dest, "wb") as f:
             for chunk in r.iter_content(chunk_size=8192):
                 f.write(chunk)
-        print(f"Saved texconv to {dest}")
-        
+        print(f"Saved texconv to {dest}")  
 
     print(f"    Regenerating {mip_count} mipmaps for {os.path.basename(dds_path)}...")
     try:

--- a/repack.py
+++ b/repack.py
@@ -41,7 +41,7 @@ def regenerate_mipmaps(dds_path, mip_count):
         "-o", temp_dir_win,
         dds_path_win
     ]
-    print(f"{cmd}")
+    #print(f"{cmd}")
 
     if not os.path.exists("./texconv.exe"):
         url = "https://github.com/microsoft/DirectXTex/releases/download/oct2025/texconv.exe"
@@ -57,7 +57,7 @@ def regenerate_mipmaps(dds_path, mip_count):
 
     print(f"    Regenerating {mip_count} mipmaps for {os.path.basename(dds_path)}...")
     try:
-        subprocess.run(cmd, check=True)
+        subprocess.run(cmd, check=True, capture_output=True)
     except subprocess.CalledProcessError as e:
         print(f"    texconv failed: {e}")
         return dds_path


### PR DESCRIPTION
One thing I forgot to put in the commit message—fixed the filename case issue for Linux. Windows (in its infinite wisdom) doesn't respect casing, but Linux does. `.DDS` != `.dds`  on Linux, but == on Windows.